### PR TITLE
fix: security audit remediation — SSRF, IDOR, PII, lockout, error handling

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -16,5 +16,5 @@ Sentry.init({
 
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
+  sendDefaultPii: false,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -15,5 +15,5 @@ Sentry.init({
 
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
+  sendDefaultPii: false,
 });

--- a/src/app/api/accessories/route.ts
+++ b/src/app/api/accessories/route.ts
@@ -14,7 +14,7 @@ import {
   buildPrismaArgs,
   buildPaginatedResponse,
 } from "@/lib/pagination";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 import {
   createAuditLog,
   createAuditLogWithDiff,
@@ -156,7 +156,10 @@ export async function POST(req: NextRequest) {
     const validationResult = accessorySchema.safeParse(normalized);
     if (!validationResult.success) {
       return NextResponse.json(
-        { error: "Validation failed", details: validationResult.error.issues },
+        {
+          error: "Validation failed",
+          details: validationResult.error.issues.map((i) => i.message),
+        },
         { status: 400 },
       );
     }
@@ -204,7 +207,7 @@ export async function POST(req: NextRequest) {
         accessoriename: created.accessoriename,
         accessorietag: created.accessorietag,
       },
-    }).catch(() => {});
+    }).catch(logCatchError("Audit log failed"));
     return NextResponse.json(created, { status: 201 });
   } catch (e) {
     logger.error("POST /api/accessories error", { error: e });
@@ -262,7 +265,10 @@ export async function PUT(req: NextRequest) {
     const validationResult = updateSchema.safeParse(normalized);
     if (!validationResult.success) {
       return NextResponse.json(
-        { error: "Validation failed", details: validationResult.error.issues },
+        {
+          error: "Validation failed",
+          details: validationResult.error.issues.map((i) => i.message),
+        },
         { status: 400 },
       );
     }
@@ -291,7 +297,7 @@ export async function PUT(req: NextRequest) {
       entityId: existing.accessorieid,
       before: existing as unknown as Record<string, unknown>,
       after: updated as unknown as Record<string, unknown>,
-    }).catch(() => {});
+    }).catch(logCatchError("Audit log failed"));
     return NextResponse.json(updated, { status: 200 });
   } catch (e) {
     logger.error("PUT /api/accessories error", { error: e });

--- a/src/app/api/asset/addAsset/route.ts
+++ b/src/app/api/asset/addAsset/route.ts
@@ -8,7 +8,7 @@ import { createAssetSchema } from "@/lib/validation";
 import { triggerWebhook } from "@/lib/webhooks";
 import { notifyIntegrations } from "@/lib/integrations/slack-teams";
 import { checkAssetLimit } from "@/lib/tenant-limits";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 import { createAuditLog, AUDIT_ACTIONS, AUDIT_ENTITIES } from "@/lib/audit-log";
 
 const assetSchema = createAssetSchema
@@ -106,7 +106,7 @@ export async function POST(req: NextRequest) {
       entity: AUDIT_ENTITIES.ASSET,
       entityId: created.assetid,
       details: { assetname: created.assetname, assettag: created.assettag },
-    }).catch(() => {});
+    }).catch(logCatchError("Audit log failed"));
     triggerWebhook(
       "asset.created",
       {
@@ -119,7 +119,7 @@ export async function POST(req: NextRequest) {
     notifyIntegrations("asset.created", {
       assetName: created.assetname,
       assetTag: created.assettag,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return new Response(JSON.stringify(created), { status: 201 });
   } catch (error) {

--- a/src/app/api/asset/attachments/route.ts
+++ b/src/app/api/asset/attachments/route.ts
@@ -12,6 +12,30 @@ import { isImageMimeType, generateThumbnails } from "@/lib/storage/thumbnails";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
+// Magic bytes (file signatures) for content-type validation
+// Prevents extension spoofing by checking actual file content
+const MAGIC_BYTES: Record<string, number[][]> = {
+  // Images
+  ".png": [[0x89, 0x50, 0x4e, 0x47]],
+  ".jpg": [[0xff, 0xd8, 0xff]],
+  ".jpeg": [[0xff, 0xd8, 0xff]],
+  ".gif": [[0x47, 0x49, 0x46, 0x38]],
+  ".webp": [[0x52, 0x49, 0x46, 0x46]], // RIFF header
+  ".svg": [], // Text-based, skip magic check
+  // Documents
+  ".pdf": [[0x25, 0x50, 0x44, 0x46]], // %PDF
+  ".docx": [[0x50, 0x4b, 0x03, 0x04]], // ZIP (OOXML)
+  ".xlsx": [[0x50, 0x4b, 0x03, 0x04]], // ZIP (OOXML)
+  ".csv": [], // Text-based, skip magic check
+  ".txt": [], // Text-based, skip magic check
+};
+
+function validateMagicBytes(buffer: Buffer, ext: string): boolean {
+  const signatures = MAGIC_BYTES[ext];
+  if (!signatures || signatures.length === 0) return true; // Text-based or unlisted formats skip check
+  return signatures.some((sig) => sig.every((byte, i) => buffer[i] === byte));
+}
+
 const ALLOWED_EXTENSIONS = new Set([
   ".jpg",
   ".jpeg",
@@ -144,6 +168,14 @@ export async function POST(req: NextRequest) {
 
     const bytes = await file.arrayBuffer();
     const buffer = Buffer.from(bytes);
+
+    // Validate file content matches its extension (prevents extension spoofing)
+    if (!validateMagicBytes(buffer, ext)) {
+      return NextResponse.json(
+        { error: "File content does not match its extension" },
+        { status: 400 },
+      );
+    }
 
     const storage = await getStorage();
     await storage.upload(uniqueFilename, buffer, file.type);

--- a/src/app/api/asset/checkout/[id]/route.ts
+++ b/src/app/api/asset/checkout/[id]/route.ts
@@ -4,7 +4,7 @@ import { requirePermission, requireNotDemoMode } from "@/lib/api-auth";
 import { createAuditLog, AUDIT_ACTIONS, AUDIT_ENTITIES } from "@/lib/audit-log";
 import { triggerWebhook } from "@/lib/webhooks";
 import { notifyIntegrations } from "@/lib/integrations/slack-teams";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 import {
   getOrganizationContext,
   scopeToOrganization,
@@ -135,7 +135,7 @@ export async function PUT(
         checkedOutToType: existing.checkedOutToType,
         action: "check_in",
       },
-    }).catch(() => {});
+    }).catch(logCatchError("Audit log failed"));
 
     // Webhook
     triggerWebhook("asset.checked_in", {
@@ -150,7 +150,7 @@ export async function PUT(
       assetName: existing.asset?.assetname,
       assetTag: existing.asset?.assettag,
       checkedOutToType: existing.checkedOutToType,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json(updated, { status: 200 });
   } catch (error: unknown) {

--- a/src/app/api/asset/checkout/bulk/route.ts
+++ b/src/app/api/asset/checkout/bulk/route.ts
@@ -9,7 +9,7 @@ import {
   getOrganizationContext,
   scopeToOrganization,
 } from "@/lib/organization-context";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 
 // POST /api/asset/checkout/bulk
 // Body: { assetIds, checkedOutToType, checkedOutTo?, checkedOutToLocationId?, checkedOutToAssetId?, expectedReturn?, notes? }
@@ -130,7 +130,7 @@ export async function POST(req: Request) {
         targetLabel,
         assetIds: foundAssets.map((a) => a.assetid),
       },
-    }).catch(() => {});
+    }).catch(logCatchError("Audit log failed"));
 
     // Webhook
     triggerWebhook("asset.bulk_checked_out", {
@@ -145,7 +145,7 @@ export async function POST(req: Request) {
       count: checkouts.length,
       targetLabel,
       checkedOutToType,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     const failed = missingAssetIds.map((id: string) => ({
       assetId: id,

--- a/src/app/api/asset/checkout/route.ts
+++ b/src/app/api/asset/checkout/route.ts
@@ -9,7 +9,7 @@ import {
   getOrganizationContext,
   scopeToOrganization,
 } from "@/lib/organization-context";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 
 // GET /api/asset/checkout?assetId=<uuid>
 export async function GET(req: Request) {
@@ -175,7 +175,7 @@ export async function POST(req: Request) {
         checkedOutToType,
         targetLabel,
       },
-    }).catch(() => {});
+    }).catch(logCatchError("Audit log failed"));
 
     // Webhook
     triggerWebhook("asset.checked_out", {
@@ -192,7 +192,7 @@ export async function POST(req: Request) {
       assetTag: asset.assettag,
       checkedOutToType,
       targetLabel,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json(checkout, { status: 201 });
   } catch (error: unknown) {

--- a/src/app/api/asset/route.ts
+++ b/src/app/api/asset/route.ts
@@ -25,7 +25,7 @@ import {
 import { triggerWebhook } from "@/lib/webhooks";
 import { notifyIntegrations } from "@/lib/integrations/slack-teams";
 import { checkAssetLimit } from "@/lib/tenant-limits";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 import { conflictResponse } from "@/lib/concurrency";
 import {
   createAuditLog,
@@ -217,7 +217,7 @@ export async function POST(req: NextRequest) {
       entity: AUDIT_ENTITIES.ASSET,
       entityId: created.assetid,
       details: { assetname: created.assetname, assettag: created.assettag },
-    }).catch(() => {});
+    }).catch(logCatchError("Audit log failed"));
     triggerWebhook("asset.created", {
       assetId: created.assetid,
       assetName: created.assetname,
@@ -226,7 +226,7 @@ export async function POST(req: NextRequest) {
     notifyIntegrations("asset.created", {
       assetName: created.assetname,
       assetTag: created.assettag,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json(created, { status: 201 });
   } catch (error) {
@@ -298,7 +298,7 @@ export async function PUT(req: NextRequest) {
       entityId: existing.assetid,
       before: existing as unknown as Record<string, unknown>,
       after: updated as unknown as Record<string, unknown>,
-    }).catch(() => {});
+    }).catch(logCatchError("Audit log failed"));
     triggerWebhook("asset.updated", {
       assetId: updated.assetid,
       assetName: updated.assetname,
@@ -307,7 +307,7 @@ export async function PUT(req: NextRequest) {
     notifyIntegrations("asset.updated", {
       assetName: updated.assetname,
       assetTag: updated.assettag,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json(updated, { status: 200 });
   } catch (error) {

--- a/src/app/api/asset/updateStatus/route.ts
+++ b/src/app/api/asset/updateStatus/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from "next/server";
 import prisma from "../../../../lib/prisma";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 import { requirePermission, requireNotDemoMode } from "@/lib/api-auth";
 import {
   getOrganizationContext,
@@ -146,7 +146,7 @@ export async function PUT(req: NextRequest) {
     notifyIntegrations("asset.updated", {
       assetName: updated.assetname,
       assetTag: updated.assettag,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     const duration = Date.now() - startTime;
     logger.apiResponse("PUT", "/api/asset/updateStatus", 200, duration, {

--- a/src/app/api/audits/[id]/complete/route.ts
+++ b/src/app/api/audits/[id]/complete/route.ts
@@ -4,7 +4,7 @@ import { requirePermission, requireNotDemoMode } from "@/lib/api-auth";
 import { createAuditLog, AUDIT_ACTIONS, AUDIT_ENTITIES } from "@/lib/audit-log";
 import { triggerWebhook } from "@/lib/webhooks";
 import { notifyIntegrations } from "@/lib/integrations/slack-teams";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -45,9 +45,13 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     // Summary stats
     const total = campaign.entries.length;
     const found = campaign.entries.filter((e) => e.status === "found").length;
-    const missing = campaign.entries.filter((e) => e.status === "missing").length;
+    const missing = campaign.entries.filter(
+      (e) => e.status === "missing",
+    ).length;
     const moved = campaign.entries.filter((e) => e.status === "moved").length;
-    const unscanned = campaign.entries.filter((e) => e.status === "unscanned").length;
+    const unscanned = campaign.entries.filter(
+      (e) => e.status === "unscanned",
+    ).length;
 
     await createAuditLog({
       userId: authUser.id,
@@ -68,7 +72,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
       campaignName: campaign.name,
       found,
       total,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json(
       { ...updated, summary: { total, found, missing, moved, unscanned } },

--- a/src/app/api/audits/route.ts
+++ b/src/app/api/audits/route.ts
@@ -9,7 +9,7 @@ import {
 } from "@/lib/validation";
 import { triggerWebhook } from "@/lib/webhooks";
 import { notifyIntegrations } from "@/lib/integrations/slack-teams";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 import {
   getOrganizationContext,
   scopeToOrganization,
@@ -142,7 +142,7 @@ export async function POST(req: Request) {
     }).catch(() => {});
     notifyIntegrations("audit.campaign_created", {
       campaignName: campaign.name,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json(campaign, { status: 201 });
   } catch (e: any) {

--- a/src/app/api/components/checkout/[id]/route.ts
+++ b/src/app/api/components/checkout/[id]/route.ts
@@ -5,7 +5,7 @@ import { createAuditLog, AUDIT_ACTIONS, AUDIT_ENTITIES } from "@/lib/audit-log";
 import { validateBody, componentCheckinSchema } from "@/lib/validation";
 import { triggerWebhook } from "@/lib/webhooks";
 import { notifyIntegrations } from "@/lib/integrations/slack-teams";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -145,7 +145,7 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
     notifyIntegrations("component.checked_in", {
       componentName: existing.component.name,
       quantity: existing.quantity,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json(checkin, { status: 200 });
   } catch (e: any) {

--- a/src/app/api/components/checkout/route.ts
+++ b/src/app/api/components/checkout/route.ts
@@ -5,7 +5,7 @@ import { createAuditLog, AUDIT_ACTIONS, AUDIT_ENTITIES } from "@/lib/audit-log";
 import { validateBody, componentCheckoutSchema } from "@/lib/validation";
 import { triggerWebhook } from "@/lib/webhooks";
 import { notifyIntegrations } from "@/lib/integrations/slack-teams";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 
 // GET /api/components/checkout?componentId=...
 export async function GET(req: Request) {
@@ -140,7 +140,7 @@ export async function POST(req: Request) {
     notifyIntegrations("component.checked_out", {
       componentName: component.name,
       quantity,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     // Check remaining stock after checkout and trigger low stock alerts
     const remainingStock = component.remainingQuantity - quantity;
@@ -156,7 +156,7 @@ export async function POST(req: Request) {
         componentName: component.name,
         quantity: remainingStock,
         minQuantity: minQty,
-      }).catch(() => {});
+      }).catch(logCatchError("Integration notification failed"));
     }
 
     return NextResponse.json(checkout, { status: 201 });

--- a/src/app/api/components/route.ts
+++ b/src/app/api/components/route.ts
@@ -10,7 +10,7 @@ import {
 } from "@/lib/validation";
 import { triggerWebhook } from "@/lib/webhooks";
 import { notifyIntegrations } from "@/lib/integrations/slack-teams";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 import {
   getOrganizationContext,
   scopeToOrganization,
@@ -172,7 +172,7 @@ export async function POST(req: Request) {
     }).catch(() => {});
     notifyIntegrations("component.created", {
       componentName: created.name,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json(created, { status: 201 });
   } catch (e: any) {
@@ -273,7 +273,7 @@ export async function PUT(req: Request) {
     }).catch(() => {});
     notifyIntegrations("component.updated", {
       componentName: updated.name,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json(updated, { status: 200 });
   } catch (e: any) {
@@ -352,7 +352,7 @@ export async function DELETE(req: Request) {
     }).catch(() => {});
     notifyIntegrations("component.deleted", {
       componentName: component.name,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json(
       { message: "Component deleted successfully" },

--- a/src/app/api/consumable/checkout/route.ts
+++ b/src/app/api/consumable/checkout/route.ts
@@ -9,7 +9,7 @@ import {
   getOrganizationContext,
   scopeToOrganization,
 } from "@/lib/organization-context";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 
 // GET /api/consumable/checkout?consumableId=...
 export async function GET(req: Request) {
@@ -186,7 +186,7 @@ export async function POST(req: Request) {
         consumableName: consumable!.consumablename,
         quantity: remainingStock,
         minQuantity: minQty,
-      }).catch(() => {});
+      }).catch(logCatchError("Integration notification failed"));
     } else if (minQty > 0 && remainingStock <= minQty) {
       triggerWebhook("consumable.low_stock", {
         consumableId,
@@ -198,7 +198,7 @@ export async function POST(req: Request) {
         consumableName: consumable!.consumablename,
         quantity: remainingStock,
         minQuantity: minQty,
-      }).catch(() => {});
+      }).catch(logCatchError("Integration notification failed"));
     }
 
     return NextResponse.json(checkout, { status: 201 });

--- a/src/app/api/cron/demo-reset/route.ts
+++ b/src/app/api/cron/demo-reset/route.ts
@@ -477,6 +477,17 @@ export async function GET(req: Request) {
     );
   }
 
+  // Extra safety: never allow demo reset when DEMO_ALLOW_RESET is not explicitly set
+  if (process.env.DEMO_ALLOW_RESET !== "true") {
+    logger.warn(
+      "Demo reset blocked: DEMO_ALLOW_RESET is not set. Set DEMO_ALLOW_RESET=true to enable.",
+    );
+    return NextResponse.json(
+      { error: "Demo reset is disabled. Set DEMO_ALLOW_RESET=true to enable." },
+      { status: 403 },
+    );
+  }
+
   const startTime = Date.now();
 
   try {

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -5,7 +5,7 @@ import { importJobSchema } from "@/lib/validation-organization";
 import { createAuditLog, AUDIT_ACTIONS } from "@/lib/audit-log";
 import { triggerWebhook } from "@/lib/webhooks";
 import { notifyIntegrations } from "@/lib/integrations/slack-teams";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
 import crypto from "crypto";
@@ -302,7 +302,7 @@ export async function POST(req: NextRequest) {
       successCount,
       errorCount: errors.length,
       totalRows: lines.length - 1,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json(completedJob, { status: 201 });
   } catch (error) {
@@ -592,7 +592,7 @@ async function createEntity(
             password: randomPassword,
           },
         })
-        .catch(() => {});
+        .catch(logCatchError("BetterAuth credential sync failed"));
       break;
     }
 

--- a/src/app/api/kits/[id]/checkout/route.ts
+++ b/src/app/api/kits/[id]/checkout/route.ts
@@ -4,7 +4,7 @@ import { requirePermission, requireNotDemoMode } from "@/lib/api-auth";
 import { createAuditLog, AUDIT_ACTIONS, AUDIT_ENTITIES } from "@/lib/audit-log";
 import { triggerWebhook } from "@/lib/webhooks";
 import { notifyIntegrations } from "@/lib/integrations/slack-teams";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -54,7 +54,12 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
       );
     }
 
-    const results: { entityType: string; entityId: string; status: string; detail?: string }[] = [];
+    const results: {
+      entityType: string;
+      entityId: string;
+      status: string;
+      detail?: string;
+    }[] = [];
 
     // Process each kit item
     await prisma.$transaction(async (tx) => {
@@ -178,7 +183,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     notifyIntegrations("kit.checked_out", {
       kitName: kit.name,
       userName: `${targetUser.firstname} ${targetUser.lastname}`,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json({ kitId: id, results }, { status: 201 });
   } catch (e: any) {

--- a/src/app/api/licence/seats/[id]/route.ts
+++ b/src/app/api/licence/seats/[id]/route.ts
@@ -4,7 +4,7 @@ import { requirePermission, requireNotDemoMode } from "@/lib/api-auth";
 import { createAuditLog, AUDIT_ACTIONS, AUDIT_ENTITIES } from "@/lib/audit-log";
 import { triggerWebhook } from "@/lib/webhooks";
 import { notifyIntegrations } from "@/lib/integrations/slack-teams";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 import { getOrganizationContext } from "@/lib/organization-context";
 
 // GET /api/licence/seats/[id]
@@ -181,7 +181,7 @@ export async function DELETE(
       seatNumber: existing.seatNumber,
       userName,
       licenceName: existing.licence.licencekey,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json(updated, { status: 200 });
   } catch (e: any) {

--- a/src/app/api/licence/seats/route.ts
+++ b/src/app/api/licence/seats/route.ts
@@ -5,7 +5,7 @@ import { createAuditLog, AUDIT_ACTIONS, AUDIT_ENTITIES } from "@/lib/audit-log";
 import { validateBody, assignLicenceSeatSchema } from "@/lib/validation";
 import { triggerWebhook } from "@/lib/webhooks";
 import { notifyIntegrations } from "@/lib/integrations/slack-teams";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 
 // GET /api/licence/seats?licenceId=...
 export async function GET(req: Request) {
@@ -208,7 +208,7 @@ export async function POST(req: Request) {
       seatNumber: assignment.seatNumber,
       userName:
         `${assignment.user.firstname ?? ""} ${assignment.user.lastname ?? ""}`.trim(),
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json(assignment, { status: 201 });
   } catch (e: any) {

--- a/src/app/api/maintenance/route.ts
+++ b/src/app/api/maintenance/route.ts
@@ -12,7 +12,7 @@ import {
   buildPrismaArgs,
   buildPaginatedResponse,
 } from "@/lib/pagination";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 
 const MAINTENANCE_SORT_FIELDS = [
   "title",
@@ -203,7 +203,7 @@ export async function POST(req: NextRequest) {
     notifyIntegrations("maintenance.due", {
       maintenanceTitle: schedule.title,
       assetName: schedule.asset?.assetname,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     return NextResponse.json(schedule, { status: 201 });
   } catch (error) {

--- a/src/app/api/organizations/[id]/route.ts
+++ b/src/app/api/organizations/[id]/route.ts
@@ -21,6 +21,13 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    // Prevent IDOR — users may only view their own organization
+    const userOrgId = (session.user as { organizationId?: string })
+      .organizationId;
+    if (userOrgId !== id && !session.user.isadmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     const organization = await prisma.organization.findUnique({
       where: { id },
       include: {
@@ -126,7 +133,13 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
   } catch (error) {
     logger.error("Error updating organization", { error });
     if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: error.issues }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: "Validation failed",
+          details: error.issues.map((i) => i.message),
+        },
+        { status: 400 },
+      );
     }
     return NextResponse.json(
       { error: "Failed to update organization" },

--- a/src/app/api/requests/route.ts
+++ b/src/app/api/requests/route.ts
@@ -7,7 +7,7 @@ import {
   requireNotDemoMode,
 } from "@/lib/api-auth";
 import { createAuditLog, AUDIT_ACTIONS } from "@/lib/audit-log";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 
 // Transaction client type — works with both the full PrismaClient and the
 // transaction-scoped client that Prisma passes into $transaction callbacks.
@@ -255,7 +255,7 @@ export async function POST(req: NextRequest) {
       entity: entityType,
       entityId,
       details: { entityName, status: initialStatus, notes: notes || null },
-    }).catch(() => {});
+    }).catch(logCatchError("Audit log failed"));
 
     // Notify all admins (in-app via notification_queue)
     try {
@@ -458,7 +458,7 @@ export async function PUT(req: NextRequest) {
         newStatus: status,
         notes: notes || null,
       },
-    }).catch(() => {});
+    }).catch(logCatchError("Audit log failed"));
 
     // Notify the requester
     try {

--- a/src/app/api/scim/v2/Users/route.ts
+++ b/src/app/api/scim/v2/Users/route.ts
@@ -9,7 +9,7 @@ import {
   userToScim,
   scimListResponse,
 } from "@/lib/scim";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 import { createAuditLog, AUDIT_ACTIONS, AUDIT_ENTITIES } from "@/lib/audit-log";
 
 const USER_SELECT = {
@@ -170,7 +170,7 @@ export async function POST(req: Request) {
           password: randomPassword,
         },
       })
-      .catch(() => {});
+      .catch(logCatchError("BetterAuth credential sync failed"));
 
     await createAuditLog({
       userId: user.userid,

--- a/src/app/api/stock-alerts/route.ts
+++ b/src/app/api/stock-alerts/route.ts
@@ -15,7 +15,7 @@ import { createAuditLog, AUDIT_ACTIONS } from "@/lib/audit-log";
 import { triggerWebhook } from "@/lib/webhooks";
 import { notifyIntegrations } from "@/lib/integrations/slack-teams";
 import { z } from "zod";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 
 // Get all stock alerts with optional low-stock filter
 export async function GET(req: NextRequest) {
@@ -212,7 +212,7 @@ export async function PUT() {
           consumableName: alert.consumable.consumablename,
           quantity: qty,
           minQuantity: alert.criticalThreshold,
-        }).catch(() => {});
+        }).catch(logCatchError("Integration notification failed"));
         triggered.push({
           consumableName: alert.consumable.consumablename,
           quantity: qty,
@@ -241,7 +241,7 @@ export async function PUT() {
           consumableName: alert.consumable.consumablename,
           quantity: qty,
           minQuantity: alert.minThreshold,
-        }).catch(() => {});
+        }).catch(logCatchError("Integration notification failed"));
         triggered.push({
           consumableName: alert.consumable.consumablename,
           quantity: qty,

--- a/src/app/api/user/addUser/route.ts
+++ b/src/app/api/user/addUser/route.ts
@@ -11,7 +11,7 @@ import { notifyIntegrations } from "@/lib/integrations/slack-teams";
 import { checkUserLimit } from "@/lib/tenant-limits";
 import { sendSetPasswordLink } from "@/lib/magic-link";
 import crypto from "crypto";
-import { logger } from "@/lib/logger";
+import { logger, logCatchError } from "@/lib/logger";
 import { getBaseUrl } from "@/lib/url";
 
 // POST /api/user/addUser
@@ -41,7 +41,7 @@ export async function POST(request) {
       return NextResponse.json(
         {
           error: "Validation failed",
-          details: validationResult.error.issues,
+          details: validationResult.error.issues.map((i) => i.message),
         },
         { status: 400 },
       );
@@ -200,7 +200,7 @@ export async function POST(request) {
     ).catch(() => {});
     notifyIntegrations("user.created", {
       email: created.email,
-    }).catch(() => {});
+    }).catch(logCatchError("Integration notification failed"));
 
     // Remove password from response
     const { password: _, ...userWithoutPassword } = created;
@@ -217,15 +217,15 @@ export async function POST(request) {
     logger.error("POST /api/user/addUser error", { error });
 
     // Handle specific error types
-    if (error.message === "Unauthorized") {
+    if (error instanceof Error && error.message === "Unauthorized") {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
-    if (error.message.startsWith("Forbidden")) {
+    if (error instanceof Error && error.message.startsWith("Forbidden")) {
       return NextResponse.json({ error: error.message }, { status: 403 });
     }
 
     // Handle unique constraint violations
-    if (error.code === "P2002") {
+    if (error instanceof Object && "code" in error && error.code === "P2002") {
       return NextResponse.json(
         {
           error: "A user with this username or email already exists",

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -25,7 +25,7 @@ Sentry.init({
 
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
+  sendDefaultPii: false,
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/src/lib/account-lockout.ts
+++ b/src/lib/account-lockout.ts
@@ -1,24 +1,62 @@
 /**
- * Account lockout module
- * Implements account lockout after failed login attempts
+ * PostgreSQL-backed account lockout module.
+ *
+ * Uses the "account_lockouts" table for distributed lockout tracking that works
+ * correctly in serverless environments (Vercel) where each invocation has its
+ * own memory. All state is persisted in PostgreSQL via Prisma raw queries.
+ *
+ * Follows the same self-healing, fail-open pattern as rate-limit.ts.
  */
 
+import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { isFeatureEnabled } from "@/lib/feature-flags";
 
-interface LockoutEntry {
-  failedAttempts: number;
-  lockedUntil: number | null;
-  lastAttempt: number;
+const S = process.env.DB_SCHEMA || "assettool";
+if (!/^[a-zA-Z0-9_]+$/.test(S)) {
+  throw new Error(
+    `Invalid DB_SCHEMA: "${S}". Only alphanumeric and underscores allowed.`,
+  );
+}
+const LOCKOUT_TABLE = `"${S}"."account_lockouts"`;
+
+// ---------------------------------------------------------------------------
+// Self-healing table creation
+// ---------------------------------------------------------------------------
+
+let tableChecked = false;
+let _ensurePromise: Promise<void> | null = null;
+
+async function ensureLockoutTable(): Promise<void> {
+  if (tableChecked) return;
+  if (_ensurePromise) return _ensurePromise;
+
+  _ensurePromise = (async () => {
+    try {
+      await prisma.$executeRawUnsafe(`
+				CREATE UNLOGGED TABLE IF NOT EXISTS ${LOCKOUT_TABLE} (
+					"key"             VARCHAR(255) PRIMARY KEY,
+					"failed_attempts" INTEGER NOT NULL DEFAULT 0,
+					"locked_until"    TIMESTAMPTZ,
+					"last_attempt"    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+				)
+			`);
+      tableChecked = true;
+    } catch (e) {
+      logger.error("[account-lockout] ensureLockoutTable failed", {
+        error: e,
+      });
+    } finally {
+      _ensurePromise = null;
+    }
+  })();
+  return _ensurePromise;
 }
 
-// In-memory storage for lockout tracking
-// In production, consider using Redis for distributed deployments
-const lockoutStore = new Map<string, LockoutEntry>();
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
 
-/**
- * Lockout configuration
- */
 export const LOCKOUT_CONFIG = {
   /** Maximum failed attempts before lockout */
   maxAttempts: 5,
@@ -26,208 +64,262 @@ export const LOCKOUT_CONFIG = {
   lockoutDurationMs: 15 * 60 * 1000,
   /** Time window for counting failed attempts (1 hour) */
   attemptWindowMs: 60 * 60 * 1000,
-  /** Progressive lockout - increase duration with repeated lockouts */
+  /** Progressive lockout — increase duration with repeated lockouts */
   progressiveLockout: true,
   /** Maximum lockout duration (24 hours) */
   maxLockoutDurationMs: 24 * 60 * 60 * 1000,
 };
 
-/**
- * Clean up expired entries periodically
- */
-const CLEANUP_INTERVAL = 60000; // 1 minute
-let cleanupTimer: NodeJS.Timeout | null = null;
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
 
-function startCleanup() {
-  if (cleanupTimer) return;
-  cleanupTimer = setInterval(() => {
-    const now = Date.now();
-    for (const [key, entry] of lockoutStore.entries()) {
-      // Remove entries that are no longer locked and have old attempts
-      if (!entry.lockedUntil && now - entry.lastAttempt > LOCKOUT_CONFIG.attemptWindowMs) {
-        lockoutStore.delete(key);
-      }
-      // Remove entries where lockout has expired and no recent attempts
-      if (entry.lockedUntil && entry.lockedUntil < now && now - entry.lastAttempt > LOCKOUT_CONFIG.attemptWindowMs) {
-        lockoutStore.delete(key);
-      }
-    }
-  }, CLEANUP_INTERVAL);
-  
-  if (cleanupTimer.unref) {
-    cleanupTimer.unref();
-  }
-}
-
-startCleanup();
-
-/**
- * Get the lockout entry for a user
- */
-function getEntry(identifier: string): LockoutEntry {
-  let entry = lockoutStore.get(identifier);
-  
-  if (!entry) {
-    entry = {
-      failedAttempts: 0,
-      lockedUntil: null,
-      lastAttempt: 0,
-    };
-    lockoutStore.set(identifier, entry);
-  }
-
-  return entry;
+interface LockoutRow {
+  failed_attempts: number;
+  locked_until: Date | null;
+  last_attempt: Date;
 }
 
 /**
- * Check if an account is currently locked
+ * Check if an account is currently locked.
  */
-export function isAccountLocked(identifier: string): { locked: boolean; remainingMs?: number; unlockTime?: Date } {
-  // Check if feature is enabled
+export async function isAccountLocked(
+  identifier: string,
+): Promise<{ locked: boolean; remainingMs?: number; unlockTime?: Date }> {
   if (!isFeatureEnabled("accountLockout")) {
     return { locked: false };
   }
 
-  const entry = getEntry(identifier);
-  const now = Date.now();
+  try {
+    await ensureLockoutTable();
 
-  if (entry.lockedUntil && entry.lockedUntil > now) {
-    const remainingMs = entry.lockedUntil - now;
-    return {
-      locked: true,
-      remainingMs,
-      unlockTime: new Date(entry.lockedUntil),
-    };
+    const rows = await prisma.$queryRawUnsafe<LockoutRow[]>(
+      `SELECT "failed_attempts", "locked_until", "last_attempt"
+			 FROM ${LOCKOUT_TABLE}
+			 WHERE "key" = $1`,
+      identifier,
+    );
+
+    if (rows.length === 0) return { locked: false };
+
+    const row = rows[0];
+    if (row.locked_until && new Date(row.locked_until) > new Date()) {
+      const remainingMs = new Date(row.locked_until).getTime() - Date.now();
+      return {
+        locked: true,
+        remainingMs,
+        unlockTime: new Date(row.locked_until),
+      };
+    }
+
+    return { locked: false };
+  } catch (e) {
+    logger.error("[account-lockout] isAccountLocked failed", { error: e });
+    // Fail open — don't block logins if DB is down
+    return { locked: false };
   }
-
-  return { locked: false };
 }
 
 /**
- * Record a failed login attempt
- * Returns the lockout status after recording the attempt
+ * Record a failed login attempt.
+ * Returns the lockout status after recording the attempt.
  */
-export function recordFailedAttempt(
+export async function recordFailedAttempt(
   identifier: string,
-  context?: { ipAddress?: string; userAgent?: string }
-): {
+  context?: { ipAddress?: string; userAgent?: string },
+): Promise<{
   locked: boolean;
   attemptsRemaining: number;
   lockoutDurationMs?: number;
   unlockTime?: Date;
-} {
-  // Check if feature is enabled
+}> {
   if (!isFeatureEnabled("accountLockout")) {
     return { locked: false, attemptsRemaining: LOCKOUT_CONFIG.maxAttempts };
   }
 
-  const entry = getEntry(identifier);
-  const now = Date.now();
+  try {
+    await ensureLockoutTable();
 
-  // Reset attempts if outside the window
-  if (now - entry.lastAttempt > LOCKOUT_CONFIG.attemptWindowMs) {
-    entry.failedAttempts = 0;
-    entry.lockedUntil = null;
-  }
+    const windowSeconds = LOCKOUT_CONFIG.attemptWindowMs / 1000;
 
-  // Increment failed attempts
-  entry.failedAttempts++;
-  entry.lastAttempt = now;
-
-  logger.securityEvent("Failed login attempt", {
-    identifier,
-    failedAttempts: entry.failedAttempts,
-    maxAttempts: LOCKOUT_CONFIG.maxAttempts,
-    ...context,
-  });
-
-  // Check if we should lock the account
-  if (entry.failedAttempts >= LOCKOUT_CONFIG.maxAttempts) {
-    // Calculate lockout duration (progressive if enabled)
-    let lockoutDuration = LOCKOUT_CONFIG.lockoutDurationMs;
-    
-    if (LOCKOUT_CONFIG.progressiveLockout) {
-      // Double the lockout duration for each lockout (up to max)
-      const lockoutCount = Math.floor(entry.failedAttempts / LOCKOUT_CONFIG.maxAttempts);
-      lockoutDuration = Math.min(
-        LOCKOUT_CONFIG.lockoutDurationMs * Math.pow(2, lockoutCount - 1),
-        LOCKOUT_CONFIG.maxLockoutDurationMs
-      );
-    }
-
-    entry.lockedUntil = now + lockoutDuration;
-
-    logger.securityEvent("Account locked", {
+    // Atomic upsert: insert or increment failed_attempts.
+    // If last_attempt is older than the window, reset the counter.
+    const rows = await prisma.$queryRawUnsafe<LockoutRow[]>(
+      `INSERT INTO ${LOCKOUT_TABLE} ("key", "failed_attempts", "last_attempt")
+			 VALUES ($1, 1, NOW())
+			 ON CONFLICT ("key") DO UPDATE
+			   SET "failed_attempts" = CASE
+			                             WHEN ${LOCKOUT_TABLE}."last_attempt" < NOW() - make_interval(secs => $2)
+			                               THEN 1
+			                             ELSE ${LOCKOUT_TABLE}."failed_attempts" + 1
+			                           END,
+			       "last_attempt" = NOW(),
+			       "locked_until" = CASE
+			                          WHEN ${LOCKOUT_TABLE}."locked_until" IS NOT NULL
+			                               AND ${LOCKOUT_TABLE}."locked_until" > NOW()
+			                            THEN ${LOCKOUT_TABLE}."locked_until"
+			                          ELSE NULL
+			                        END
+			 RETURNING "failed_attempts", "locked_until", "last_attempt"`,
       identifier,
-      lockoutDurationMs: lockoutDuration,
-      unlockTime: new Date(entry.lockedUntil).toISOString(),
-      failedAttempts: entry.failedAttempts,
+      windowSeconds,
+    );
+
+    const row = rows[0];
+
+    logger.securityEvent("Failed login attempt", {
+      identifier,
+      failedAttempts: row.failed_attempts,
+      maxAttempts: LOCKOUT_CONFIG.maxAttempts,
       ...context,
     });
 
+    if (row.failed_attempts >= LOCKOUT_CONFIG.maxAttempts) {
+      // Calculate progressive lockout duration
+      const lockoutCount = Math.floor(
+        row.failed_attempts / LOCKOUT_CONFIG.maxAttempts,
+      );
+      const lockoutDuration = LOCKOUT_CONFIG.progressiveLockout
+        ? Math.min(
+            LOCKOUT_CONFIG.lockoutDurationMs * Math.pow(2, lockoutCount - 1),
+            LOCKOUT_CONFIG.maxLockoutDurationMs,
+          )
+        : LOCKOUT_CONFIG.lockoutDurationMs;
+
+      const lockoutSeconds = lockoutDuration / 1000;
+
+      // Set the locked_until timestamp
+      await prisma.$executeRawUnsafe(
+        `UPDATE ${LOCKOUT_TABLE}
+				 SET "locked_until" = NOW() + make_interval(secs => $2)
+				 WHERE "key" = $1`,
+        identifier,
+        lockoutSeconds,
+      );
+
+      const unlockTime = new Date(Date.now() + lockoutDuration);
+
+      logger.securityEvent("Account locked", {
+        identifier,
+        lockoutDurationMs: lockoutDuration,
+        unlockTime: unlockTime.toISOString(),
+        failedAttempts: row.failed_attempts,
+        ...context,
+      });
+
+      return {
+        locked: true,
+        attemptsRemaining: 0,
+        lockoutDurationMs: lockoutDuration,
+        unlockTime,
+      };
+    }
+
     return {
-      locked: true,
-      attemptsRemaining: 0,
-      lockoutDurationMs: lockoutDuration,
-      unlockTime: new Date(entry.lockedUntil),
+      locked: false,
+      attemptsRemaining: LOCKOUT_CONFIG.maxAttempts - row.failed_attempts,
+    };
+  } catch (e) {
+    logger.error("[account-lockout] recordFailedAttempt failed", {
+      error: e,
+    });
+    // Fail open
+    return {
+      locked: false,
+      attemptsRemaining: LOCKOUT_CONFIG.maxAttempts,
     };
   }
-
-  return {
-    locked: false,
-    attemptsRemaining: LOCKOUT_CONFIG.maxAttempts - entry.failedAttempts,
-  };
 }
 
 /**
- * Record a successful login (resets the lockout counter)
+ * Record a successful login (resets the lockout counter).
  */
-export function recordSuccessfulLogin(identifier: string): void {
-  const entry = lockoutStore.get(identifier);
-  
-  if (entry) {
-    logger.info("Successful login - resetting lockout counter", {
+export async function recordSuccessfulLogin(identifier: string): Promise<void> {
+  try {
+    await ensureLockoutTable();
+    await prisma.$executeRawUnsafe(
+      `DELETE FROM ${LOCKOUT_TABLE} WHERE "key" = $1`,
       identifier,
-      previousFailedAttempts: entry.failedAttempts,
+    );
+  } catch (e) {
+    logger.error("[account-lockout] recordSuccessfulLogin failed", {
+      error: e,
     });
-    lockoutStore.delete(identifier);
   }
 }
 
 /**
- * Manually unlock an account (admin action)
+ * Manually unlock an account (admin action).
  */
-export function unlockAccount(identifier: string, adminId?: string): boolean {
-  const entry = lockoutStore.get(identifier);
-  
-  if (!entry) {
+export async function unlockAccount(
+  identifier: string,
+  adminId?: string,
+): Promise<boolean> {
+  try {
+    await ensureLockoutTable();
+
+    const rows = await prisma.$queryRawUnsafe<LockoutRow[]>(
+      `DELETE FROM ${LOCKOUT_TABLE} WHERE "key" = $1
+			 RETURNING "failed_attempts", "locked_until", "last_attempt"`,
+      identifier,
+    );
+
+    if (rows.length === 0) return false;
+
+    logger.securityEvent("Account manually unlocked", {
+      identifier,
+      adminId,
+      previousFailedAttempts: rows[0].failed_attempts,
+      wasLocked:
+        rows[0].locked_until !== null &&
+        new Date(rows[0].locked_until) > new Date(),
+    });
+
+    return true;
+  } catch (e) {
+    logger.error("[account-lockout] unlockAccount failed", { error: e });
     return false;
   }
-
-  logger.securityEvent("Account manually unlocked", {
-    identifier,
-    adminId,
-    previousFailedAttempts: entry.failedAttempts,
-    wasLocked: entry.lockedUntil !== null && entry.lockedUntil > Date.now(),
-  });
-
-  lockoutStore.delete(identifier);
-  return true;
 }
 
 /**
- * Get lockout status for an account (admin view)
+ * Get lockout status for an account (admin view).
  */
-export function getLockoutStatus(identifier: string): {
+export async function getLockoutStatus(identifier: string): Promise<{
   failedAttempts: number;
   lockedUntil: Date | null;
   lastAttempt: Date | null;
   isLocked: boolean;
-} {
-  const entry = lockoutStore.get(identifier);
-  const now = Date.now();
+}> {
+  try {
+    await ensureLockoutTable();
 
-  if (!entry) {
+    const rows = await prisma.$queryRawUnsafe<LockoutRow[]>(
+      `SELECT "failed_attempts", "locked_until", "last_attempt"
+			 FROM ${LOCKOUT_TABLE}
+			 WHERE "key" = $1`,
+      identifier,
+    );
+
+    if (rows.length === 0) {
+      return {
+        failedAttempts: 0,
+        lockedUntil: null,
+        lastAttempt: null,
+        isLocked: false,
+      };
+    }
+
+    const row = rows[0];
+    return {
+      failedAttempts: row.failed_attempts,
+      lockedUntil: row.locked_until ? new Date(row.locked_until) : null,
+      lastAttempt: new Date(row.last_attempt),
+      isLocked:
+        row.locked_until !== null && new Date(row.locked_until) > new Date(),
+    };
+  } catch (e) {
+    logger.error("[account-lockout] getLockoutStatus failed", { error: e });
     return {
       failedAttempts: 0,
       lockedUntil: null,
@@ -235,64 +327,67 @@ export function getLockoutStatus(identifier: string): {
       isLocked: false,
     };
   }
-
-  return {
-    failedAttempts: entry.failedAttempts,
-    lockedUntil: entry.lockedUntil ? new Date(entry.lockedUntil) : null,
-    lastAttempt: entry.lastAttempt ? new Date(entry.lastAttempt) : null,
-    isLocked: entry.lockedUntil !== null && entry.lockedUntil > now,
-  };
 }
 
 /**
- * Get all locked accounts (admin view)
+ * Get all currently locked accounts (admin view).
  */
-export function getAllLockedAccounts(): Array<{
-  identifier: string;
-  failedAttempts: number;
-  lockedUntil: Date;
-  lastAttempt: Date;
-}> {
-  const now = Date.now();
-  const locked: Array<{
+export async function getAllLockedAccounts(): Promise<
+  Array<{
     identifier: string;
     failedAttempts: number;
     lockedUntil: Date;
     lastAttempt: Date;
-  }> = [];
+  }>
+> {
+  try {
+    await ensureLockoutTable();
 
-  for (const [identifier, entry] of lockoutStore.entries()) {
-    if (entry.lockedUntil && entry.lockedUntil > now) {
-      locked.push({
-        identifier,
-        failedAttempts: entry.failedAttempts,
-        lockedUntil: new Date(entry.lockedUntil),
-        lastAttempt: new Date(entry.lastAttempt),
-      });
-    }
+    const rows = await prisma.$queryRawUnsafe<
+      Array<{
+        key: string;
+        failed_attempts: number;
+        locked_until: Date;
+        last_attempt: Date;
+      }>
+    >(
+      `SELECT "key", "failed_attempts", "locked_until", "last_attempt"
+			 FROM ${LOCKOUT_TABLE}
+			 WHERE "locked_until" IS NOT NULL AND "locked_until" > NOW()`,
+    );
+
+    return rows.map((r) => ({
+      identifier: r.key,
+      failedAttempts: r.failed_attempts,
+      lockedUntil: new Date(r.locked_until),
+      lastAttempt: new Date(r.last_attempt),
+    }));
+  } catch (e) {
+    logger.error("[account-lockout] getAllLockedAccounts failed", {
+      error: e,
+    });
+    return [];
   }
-
-  return locked;
 }
 
 /**
- * Format lockout message for user display
+ * Format lockout message for user display.
  */
 export function formatLockoutMessage(remainingMs: number): string {
   const minutes = Math.ceil(remainingMs / (60 * 1000));
-  
+
   if (minutes <= 1) {
     return "Your account is temporarily locked. Please try again in about a minute.";
   }
-  
+
   if (minutes < 60) {
     return `Your account is temporarily locked. Please try again in ${minutes} minutes.`;
   }
-  
+
   const hours = Math.ceil(minutes / 60);
   if (hours === 1) {
     return "Your account is temporarily locked. Please try again in about an hour.";
   }
-  
+
   return `Your account is temporarily locked. Please try again in ${hours} hours.`;
 }

--- a/src/lib/audit-log.ts
+++ b/src/lib/audit-log.ts
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import { headers } from "next/headers";
+import { logger } from "@/lib/logger";
 
 interface AuditLogParams {
   userId: string | null;
@@ -53,7 +54,7 @@ export async function createAuditLog({
     });
   } catch (error) {
     // Log error but don't throw - audit logging shouldn't break the application
-    console.error("Failed to create audit log:", error);
+    logger.error("Failed to create audit log", { error });
   }
 }
 

--- a/src/lib/auth-server.ts
+++ b/src/lib/auth-server.ts
@@ -394,7 +394,7 @@ export const auth = betterAuth({
       const lockoutKey = user?.email ?? rawIdentifier;
 
       // Check account lockout
-      const lockStatus = isAccountLocked(lockoutKey);
+      const lockStatus = await isAccountLocked(lockoutKey);
       if (lockStatus.locked) {
         logger.securityEvent("Login attempt on locked account", {
           identifier: lockoutKey,
@@ -479,7 +479,7 @@ export const auth = betterAuth({
       // Check if login succeeded (session cookie was set)
       const setCookie = ctx.context.responseHeaders?.get("set-cookie");
       if (setCookie) {
-        recordSuccessfulLogin(identifier);
+        await recordSuccessfulLogin(identifier);
 
         const user = await prisma.user.findFirst({
           where: {
@@ -568,7 +568,7 @@ export const auth = betterAuth({
         }
       } else {
         // Login failed — single place for recording failed attempts
-        recordFailedAttempt(identifier);
+        await recordFailedAttempt(identifier);
 
         // Record failed attempt for suspicious activity detection (IP-based)
         const failedIp =

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -18,6 +18,7 @@
  */
 
 import prisma from "@/lib/prisma";
+import { logger } from "@/lib/logger";
 
 // ---------------------------------------------------------------------------
 // Schema-qualified table name — ensures raw queries work regardless of
@@ -62,7 +63,7 @@ async function ensureCacheTable(): Promise<void> {
       );
       tableChecked = true;
     } catch (e) {
-      console.error("[cache] ensureCacheTable failed:", e);
+      logger.error("[cache] ensureCacheTable failed", { error: e });
     } finally {
       _ensurePromise = null;
     }
@@ -90,7 +91,7 @@ export const cache = {
       if (rows.length === 0) return null;
       return rows[0].value as T;
     } catch (error) {
-      console.error("[cache] get failed:", error);
+      logger.error("[cache] get failed", { error });
       return null;
     }
   },
@@ -113,7 +114,7 @@ export const cache = {
         ttlSeconds,
       );
     } catch (error) {
-      console.error("[cache] set failed:", error);
+      logger.error("[cache] set failed", { error });
     }
   },
 
@@ -127,7 +128,7 @@ export const cache = {
         key,
       );
     } catch (error) {
-      console.error("[cache] del failed:", error);
+      logger.error("[cache] del failed", { error });
     }
   },
 
@@ -141,7 +142,7 @@ export const cache = {
         prefix + "%",
       );
     } catch (error) {
-      console.error("[cache] invalidatePattern failed:", error);
+      logger.error("[cache] invalidatePattern failed", { error });
     }
   },
 
@@ -152,7 +153,7 @@ export const cache = {
     try {
       await prisma.$executeRawUnsafe(`DELETE FROM ${CACHE_TABLE}`);
     } catch (error) {
-      console.error("[cache] clear failed:", error);
+      logger.error("[cache] clear failed", { error });
     }
   },
 };

--- a/src/lib/email/service.ts
+++ b/src/lib/email/service.ts
@@ -89,7 +89,7 @@ async function getEmailConfig(): Promise<EmailConfig | null> {
 
     return null;
   } catch (error) {
-    console.error("Failed to get email config:", error);
+    logger.error("Failed to get email config", { error });
     return null;
   }
 }

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -10,6 +10,7 @@
  */
 
 import * as crypto from "crypto";
+import { logger } from "@/lib/logger";
 
 const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 12; // 96 bits — recommended for GCM
@@ -26,9 +27,8 @@ function getKey(): Buffer | null {
   const hex = process.env.ENCRYPTION_KEY;
   if (!hex) {
     if (!_warnedMissingKey) {
-      console.warn(
-        "[encryption] ENCRYPTION_KEY is not set — sensitive data will NOT be " +
-          "encrypted at rest. Generate one with: openssl rand -hex 32",
+      logger.warn(
+        "[encryption] ENCRYPTION_KEY is not set — sensitive data will NOT be encrypted at rest. Generate one with: openssl rand -hex 32",
       );
       _warnedMissingKey = true;
     }

--- a/src/lib/integrations/intune.ts
+++ b/src/lib/integrations/intune.ts
@@ -13,6 +13,25 @@ import { scopeToOrganization } from "@/lib/organization-context";
 import { logger } from "@/lib/logger";
 
 // ---------------------------------------------------------------------------
+// Timeout helper — 30 s default for all Graph API calls
+// ---------------------------------------------------------------------------
+
+const GRAPH_API_TIMEOUT_MS = 30_000;
+
+function fetchWithTimeout(
+  url: string,
+  init?: RequestInit,
+  timeoutMs = GRAPH_API_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  return fetch(url, { ...init, signal: controller.signal }).finally(() =>
+    clearTimeout(timer),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -98,7 +117,7 @@ async function getAccessToken(
     scope: "https://graph.microsoft.com/.default",
   });
 
-  const res = await fetch(tokenUrl, {
+  const res = await fetchWithTimeout(tokenUrl, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: body.toString(),
@@ -125,7 +144,7 @@ async function fetchManagedDevices(
     "https://graph.microsoft.com/v1.0/deviceManagement/managedDevices?$select=id,deviceName,serialNumber,manufacturer,model,operatingSystem,osVersion,complianceState,deviceType,managedDeviceOwnerType,enrolledDateTime,lastSyncDateTime&$top=1000";
 
   while (url) {
-    const res = await fetch(url, {
+    const res = await fetchWithTimeout(url, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
 

--- a/src/lib/integrations/slack-teams.ts
+++ b/src/lib/integrations/slack-teams.ts
@@ -1,4 +1,22 @@
 import prisma from "@/lib/prisma";
+import { logger } from "@/lib/logger";
+import { validateOutboundUrl } from "@/lib/url-validation";
+
+// 10 s timeout for webhook notifications — short because these are non-critical
+const WEBHOOK_TIMEOUT_MS = 10_000;
+
+function fetchWithTimeout(
+  url: string,
+  init?: RequestInit,
+  timeoutMs = WEBHOOK_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  return fetch(url, { ...init, signal: controller.signal }).finally(() =>
+    clearTimeout(timer),
+  );
+}
 
 interface IntegrationConfig {
   enabled: boolean;
@@ -247,18 +265,27 @@ export async function notifyIntegrations(
       settings.slack.webhookUrl &&
       settings.slack.events.includes(event)
     ) {
-      const payload = formatSlackMessage(
-        event,
-        data,
-        settings.slack.channel || undefined,
+      const slackUrlCheck = await validateOutboundUrl(
+        settings.slack.webhookUrl,
       );
-      promises.push(
-        fetch(settings.slack.webhookUrl, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
-        }).then(() => undefined),
-      );
+      if (slackUrlCheck.valid) {
+        const payload = formatSlackMessage(
+          event,
+          data,
+          settings.slack.channel || undefined,
+        );
+        promises.push(
+          fetchWithTimeout(settings.slack.webhookUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          }).then(() => undefined),
+        );
+      } else {
+        logger.warn("Slack webhook blocked by SSRF protection", {
+          reason: slackUrlCheck.error,
+        });
+      }
     }
 
     if (
@@ -266,18 +293,27 @@ export async function notifyIntegrations(
       settings.teams.webhookUrl &&
       settings.teams.events.includes(event)
     ) {
-      const payload = formatTeamsMessage(event, data);
-      promises.push(
-        fetch(settings.teams.webhookUrl, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
-        }).then(() => undefined),
+      const teamsUrlCheck = await validateOutboundUrl(
+        settings.teams.webhookUrl,
       );
+      if (teamsUrlCheck.valid) {
+        const payload = formatTeamsMessage(event, data);
+        promises.push(
+          fetchWithTimeout(settings.teams.webhookUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          }).then(() => undefined),
+        );
+      } else {
+        logger.warn("Teams webhook blocked by SSRF protection", {
+          reason: teamsUrlCheck.error,
+        });
+      }
     }
 
     await Promise.allSettled(promises);
   } catch (error) {
-    console.error("Integration notification error:", error);
+    logger.warn("Integration notification error", { error, event });
   }
 }

--- a/src/lib/logger/index.ts
+++ b/src/lib/logger/index.ts
@@ -343,3 +343,17 @@ export const logger = new Logger();
 
 // Export class for custom instances
 export { Logger };
+
+/**
+ * Returns a catch handler that logs the error as a warning.
+ * Use in fire-and-forget promise chains instead of silent `.catch(() => {})`.
+ *
+ * @example
+ * createAuditLog({ ... }).catch(logCatchError("Audit log failed"));
+ * notifyIntegrations("asset.created", { ... }).catch(logCatchError("Integration notification failed"));
+ */
+export function logCatchError(context: string) {
+  return (err: unknown) => {
+    logger.warn(context, { error: err });
+  };
+}

--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -1,0 +1,169 @@
+/**
+ * URL validation for SSRF protection.
+ *
+ * Validates that a URL does not point to private/internal networks,
+ * cloud metadata endpoints, or non-HTTP(S) schemes before making
+ * outbound requests (webhooks, Slack/Teams notifications, etc.).
+ */
+
+import dns from "dns/promises";
+import { logger } from "@/lib/logger";
+
+/**
+ * Check whether an IPv4 address falls within a private/reserved range.
+ *
+ * Blocked ranges:
+ *  - 0.0.0.0/8        (current network)
+ *  - 10.0.0.0/8       (private, RFC 1918)
+ *  - 100.64.0.0/10    (carrier-grade NAT, RFC 6598)
+ *  - 127.0.0.0/8      (loopback)
+ *  - 169.254.0.0/16   (link-local / cloud metadata)
+ *  - 172.16.0.0/12    (private, RFC 1918)
+ *  - 192.0.0.0/24     (IETF protocol assignments)
+ *  - 192.0.2.0/24     (documentation, TEST-NET-1)
+ *  - 192.168.0.0/16   (private, RFC 1918)
+ *  - 198.18.0.0/15    (benchmark testing)
+ *  - 198.51.100.0/24  (documentation, TEST-NET-2)
+ *  - 203.0.113.0/24   (documentation, TEST-NET-3)
+ *  - 224.0.0.0/4      (multicast)
+ *  - 240.0.0.0/4      (reserved / broadcast)
+ */
+function isPrivateIPv4(ip: string): boolean {
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((p) => isNaN(p) || p < 0 || p > 255)) {
+    return true; // Malformed → block
+  }
+
+  const [a, b] = parts;
+
+  if (a === 0) return true;
+  if (a === 10) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 0 && parts[2] === 0) return true;
+  if (a === 192 && b === 0 && parts[2] === 2) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  if (a === 198 && b === 51 && parts[2] === 100) return true;
+  if (a === 203 && b === 0 && parts[2] === 113) return true;
+  if (a >= 224) return true;
+
+  return false;
+}
+
+/**
+ * Check whether an IPv6 address is loopback, link-local, or otherwise private.
+ */
+function isPrivateIPv6(ip: string): boolean {
+  const normalized = ip.toLowerCase();
+
+  if (normalized === "::1") return true;
+  if (normalized === "::") return true;
+  if (normalized.startsWith("fe80:")) return true; // link-local
+  if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true; // unique local
+  if (normalized.startsWith("::ffff:")) {
+    // IPv4-mapped IPv6 — extract the IPv4 part and check that
+    const v4 = normalized.slice(7);
+    if (v4.includes(".")) return isPrivateIPv4(v4);
+  }
+
+  return false;
+}
+
+export interface UrlValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Validate that a URL is safe for outbound requests (no SSRF).
+ *
+ * 1. Scheme must be http or https
+ * 2. Hostname must not be empty
+ * 3. Hostname must not resolve to a private/reserved IP
+ */
+export async function validateOutboundUrl(
+  url: string,
+): Promise<UrlValidationResult> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { valid: false, error: "Invalid URL format" };
+  }
+
+  // 1. Scheme check
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return {
+      valid: false,
+      error: "Only http and https URLs are allowed",
+    };
+  }
+
+  // 2. Hostname present
+  if (!parsed.hostname) {
+    return { valid: false, error: "URL must include a hostname" };
+  }
+
+  // 3. Block common SSRF targets before DNS
+  const hostname = parsed.hostname.toLowerCase();
+  const blockedHostnames = [
+    "localhost",
+    "metadata.google.internal",
+    "metadata.google",
+  ];
+  if (blockedHostnames.includes(hostname)) {
+    return {
+      valid: false,
+      error: "This hostname is not allowed for outbound requests",
+    };
+  }
+
+  // 4. If hostname is already an IP literal, check it directly
+  if (
+    parsed.hostname.match(/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/) ||
+    parsed.hostname.startsWith("[")
+  ) {
+    const ip = parsed.hostname.replace(/^\[|\]$/g, "");
+    if (isPrivateIPv4(ip) || isPrivateIPv6(ip)) {
+      return {
+        valid: false,
+        error: "URLs pointing to private/internal networks are not allowed",
+      };
+    }
+    return { valid: true };
+  }
+
+  // 5. Resolve hostname and check all returned IPs
+  try {
+    const results = await dns.lookup(hostname, { all: true });
+
+    for (const result of results) {
+      const isPrivate =
+        result.family === 4
+          ? isPrivateIPv4(result.address)
+          : isPrivateIPv6(result.address);
+
+      if (isPrivate) {
+        logger.warn("SSRF attempt blocked: hostname resolves to private IP", {
+          url,
+          hostname,
+          resolvedIp: result.address,
+        });
+        return {
+          valid: false,
+          error: "URLs pointing to private/internal networks are not allowed",
+        };
+      }
+    }
+
+    return { valid: true };
+  } catch {
+    return {
+      valid: false,
+      error: "Could not resolve hostname",
+    };
+  }
+}

--- a/src/lib/webhooks.ts
+++ b/src/lib/webhooks.ts
@@ -1,6 +1,8 @@
 import prisma from "./prisma";
 import crypto from "crypto";
 import { decrypt } from "./encryption";
+import { validateOutboundUrl } from "./url-validation";
+import { logger } from "./logger";
 
 /**
  * Available webhook events
@@ -100,7 +102,7 @@ export async function triggerWebhook(
 
     await Promise.allSettled(deliveries);
   } catch (error) {
-    console.error("Error triggering webhooks:", error);
+    logger.error("Error triggering webhooks", { error });
   }
 }
 
@@ -132,6 +134,28 @@ async function deliverWebhook(
       payloadString,
       plaintextSecret,
     );
+  }
+
+  // SSRF protection: validate URL before making outbound request
+  const urlCheck = await validateOutboundUrl(webhook.url);
+  if (!urlCheck.valid) {
+    logger.warn("Webhook delivery blocked by SSRF protection", {
+      webhookId: webhook.id,
+      url: webhook.url,
+      reason: urlCheck.error,
+    });
+    await prisma.webhookDelivery.create({
+      data: {
+        webhookId: webhook.id,
+        event: payload.event,
+        payload: payload as object,
+        statusCode: 0,
+        response: `Blocked: ${urlCheck.error}`,
+        attempt,
+        success: false,
+      },
+    });
+    return;
   }
 
   try {

--- a/src/lib/workflow-engine.ts
+++ b/src/lib/workflow-engine.ts
@@ -4,28 +4,40 @@
  * based on triggers like warranty expiring, maintenance due, etc.
  */
 
-import prisma from './prisma';
-import { queueEmail } from './email';
-import { triggerWebhook, WebhookEvent } from './webhooks';
+import prisma from "./prisma";
+import { queueEmail } from "./email";
+import { triggerWebhook, WebhookEvent } from "./webhooks";
+import { logger } from "@/lib/logger";
 
 // Trigger types that correspond to AutomationRule.trigger values
 type WorkflowTrigger =
-  | 'warranty_expiring'
-  | 'maintenance_due'
-  | 'asset_status_change'
-  | 'license_expiring'
-  | 'stock_low';
+  | "warranty_expiring"
+  | "maintenance_due"
+  | "asset_status_change"
+  | "license_expiring"
+  | "stock_low";
 
 // Condition structure (stored as JSON in AutomationRule.conditions)
 interface WorkflowCondition {
   field: string;
-  operator: 'equals' | 'not_equals' | 'contains' | 'greater_than' | 'less_than' | 'in';
+  operator:
+    | "equals"
+    | "not_equals"
+    | "contains"
+    | "greater_than"
+    | "less_than"
+    | "in";
   value: unknown;
 }
 
 // Action structure (stored as JSON in AutomationRule.actions)
 interface WorkflowAction {
-  type: 'send_email' | 'send_notification' | 'trigger_webhook' | 'update_status' | 'create_ticket';
+  type:
+    | "send_email"
+    | "send_notification"
+    | "trigger_webhook"
+    | "update_status"
+    | "create_ticket";
   config: Record<string, unknown>;
 }
 
@@ -34,10 +46,14 @@ interface WorkflowAction {
  * e.g. getNestedValue({ asset: { status: "active" } }, "asset.status") => "active"
  */
 function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
-  const keys = path.split('.');
+  const keys = path.split(".");
   let current: unknown = obj;
   for (const key of keys) {
-    if (current === null || current === undefined || typeof current !== 'object') {
+    if (
+      current === null ||
+      current === undefined ||
+      typeof current !== "object"
+    ) {
       return undefined;
     }
     current = (current as Record<string, unknown>)[key];
@@ -48,22 +64,29 @@ function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
 /**
  * Evaluate a single condition against data
  */
-function evaluateCondition(condition: WorkflowCondition, data: Record<string, unknown>): boolean {
+function evaluateCondition(
+  condition: WorkflowCondition,
+  data: Record<string, unknown>,
+): boolean {
   const fieldValue = getNestedValue(data, condition.field);
 
   switch (condition.operator) {
-    case 'equals':
+    case "equals":
       return fieldValue === condition.value;
-    case 'not_equals':
+    case "not_equals":
       return fieldValue !== condition.value;
-    case 'contains':
-      return String(fieldValue).toLowerCase().includes(String(condition.value).toLowerCase());
-    case 'greater_than':
+    case "contains":
+      return String(fieldValue)
+        .toLowerCase()
+        .includes(String(condition.value).toLowerCase());
+    case "greater_than":
       return Number(fieldValue) > Number(condition.value);
-    case 'less_than':
+    case "less_than":
       return Number(fieldValue) < Number(condition.value);
-    case 'in':
-      return Array.isArray(condition.value) && condition.value.includes(fieldValue);
+    case "in":
+      return (
+        Array.isArray(condition.value) && condition.value.includes(fieldValue)
+      );
     default:
       return false;
   }
@@ -73,7 +96,10 @@ function evaluateCondition(condition: WorkflowCondition, data: Record<string, un
  * Evaluate all conditions (AND logic).
  * If no conditions are provided, the rule matches unconditionally.
  */
-function evaluateConditions(conditions: WorkflowCondition[], data: Record<string, unknown>): boolean {
+function evaluateConditions(
+  conditions: WorkflowCondition[],
+  data: Record<string, unknown>,
+): boolean {
   if (conditions.length === 0) return true;
   return conditions.every((c) => evaluateCondition(c, data));
 }
@@ -82,45 +108,58 @@ function evaluateConditions(conditions: WorkflowCondition[], data: Record<string
  * Replace {{variable}} placeholders in a template string with values from data.
  * Supports dot-notation paths like {{asset.name}}.
  */
-function resolveTemplate(template: string, data: Record<string, unknown>): string {
+function resolveTemplate(
+  template: string,
+  data: Record<string, unknown>,
+): string {
   return template.replace(/\{\{(\w+(?:\.\w+)*)\}\}/g, (_, key) => {
     const val = getNestedValue(data, key);
-    return val !== undefined && val !== null ? String(val) : '';
+    return val !== undefined && val !== null ? String(val) : "";
   });
 }
 
 /**
  * Execute a single workflow action
  */
-async function executeAction(action: WorkflowAction, data: Record<string, unknown>): Promise<void> {
+async function executeAction(
+  action: WorkflowAction,
+  data: Record<string, unknown>,
+): Promise<void> {
   switch (action.type) {
-    case 'send_email': {
+    case "send_email": {
       // config: { to: string, subject: string, body: string } with {{variable}} template support
       const to = resolveTemplate(action.config.to as string, data);
       const subject = resolveTemplate(action.config.subject as string, data);
       const body = resolveTemplate(action.config.body as string, data);
-      await queueEmail(null, 'workflow', to, subject, body);
+      await queueEmail(null, "workflow", to, subject, body);
       break;
     }
-    case 'send_notification': {
+    case "send_notification": {
       // config: { userId: string, message: string }
       const userId = action.config.userId as string;
       const user = await prisma.user.findUnique({ where: { userid: userId } });
       if (user?.email) {
         const message = resolveTemplate(action.config.message as string, data);
-        await queueEmail(userId, 'workflow_notification', user.email, 'Workflow Notification', message);
+        await queueEmail(
+          userId,
+          "workflow_notification",
+          user.email,
+          "Workflow Notification",
+          message,
+        );
       }
       break;
     }
-    case 'trigger_webhook': {
+    case "trigger_webhook": {
       // config: { event: string }
-      const event = (action.config.event || 'asset.updated') as WebhookEvent;
+      const event = (action.config.event || "asset.updated") as WebhookEvent;
       await triggerWebhook(event, data);
       break;
     }
-    case 'update_status': {
+    case "update_status": {
       // config: { assetId?: string, statusId: string } -- falls back to data.assetId
-      const assetId = (action.config.assetId as string) || (data.assetId as string);
+      const assetId =
+        (action.config.assetId as string) || (data.assetId as string);
       const statusId = action.config.statusId as string;
       if (assetId && statusId) {
         await prisma.asset.update({
@@ -130,14 +169,23 @@ async function executeAction(action: WorkflowAction, data: Record<string, unknow
       }
       break;
     }
-    case 'create_ticket': {
+    case "create_ticket": {
       // config: { title: string, description: string, priority: string, createdBy?: string }
-      const title = resolveTemplate((action.config.title as string) || 'Automated Ticket', data);
-      const description = resolveTemplate((action.config.description as string) || '', data);
-      const createdBy = (data.userId as string) || (action.config.createdBy as string);
+      const title = resolveTemplate(
+        (action.config.title as string) || "Automated Ticket",
+        data,
+      );
+      const description = resolveTemplate(
+        (action.config.description as string) || "",
+        data,
+      );
+      const createdBy =
+        (data.userId as string) || (action.config.createdBy as string);
 
       if (!createdBy) {
-        console.warn('Workflow create_ticket action skipped: no createdBy user ID available');
+        logger.warn(
+          "Workflow create_ticket action skipped: no createdBy user ID available",
+        );
         break;
       }
 
@@ -146,17 +194,16 @@ async function executeAction(action: WorkflowAction, data: Record<string, unknow
           data: {
             title,
             description,
-            priority: (action.config.priority as string) || 'medium',
-            status: 'new',
+            priority: (action.config.priority as string) || "medium",
+            status: "new",
             createdBy,
             updatedAt: new Date(),
           },
         });
       } catch (err) {
-        console.warn(
-          'Workflow create_ticket action failed:',
-          err instanceof Error ? err.message : String(err)
-        );
+        logger.warn("Workflow create_ticket action failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
       break;
     }
@@ -170,7 +217,7 @@ async function executeAction(action: WorkflowAction, data: Record<string, unknow
  */
 export async function processWorkflowTrigger(
   trigger: WorkflowTrigger,
-  data: Record<string, unknown>
+  data: Record<string, unknown>,
 ): Promise<{ executed: number; errors: string[] }> {
   const rules = await prisma.automationRule.findMany({
     where: { trigger, isActive: true },
@@ -181,8 +228,10 @@ export async function processWorkflowTrigger(
 
   for (const rule of rules) {
     try {
-      const conditions: WorkflowCondition[] = JSON.parse(rule.conditions || '[]');
-      const actions: WorkflowAction[] = JSON.parse(rule.actions || '[]');
+      const conditions: WorkflowCondition[] = JSON.parse(
+        rule.conditions || "[]",
+      );
+      const actions: WorkflowAction[] = JSON.parse(rule.actions || "[]");
 
       if (!evaluateConditions(conditions, data)) continue;
 
@@ -200,7 +249,7 @@ export async function processWorkflowTrigger(
     } catch (err) {
       const msg = `Rule "${rule.name}" (${rule.id}): ${err instanceof Error ? err.message : String(err)}`;
       errors.push(msg);
-      console.error('Workflow execution error:', msg);
+      logger.error("Workflow execution error", { error: msg });
     }
   }
 
@@ -226,13 +275,13 @@ export async function runScheduledWorkflows(): Promise<
     },
   });
   for (const asset of warrantyAssets) {
-    const r = await processWorkflowTrigger('warranty_expiring', {
+    const r = await processWorkflowTrigger("warranty_expiring", {
       assetId: asset.assetid,
       assetName: asset.assetname,
       assetTag: asset.assettag,
       warrantyExpires: asset.warrantyExpires?.toISOString(),
     });
-    results.push({ trigger: 'warranty_expiring', ...r });
+    results.push({ trigger: "warranty_expiring", ...r });
   }
 
   // 2. Check maintenance due (within next 7 days)
@@ -247,14 +296,14 @@ export async function runScheduledWorkflows(): Promise<
     include: { asset: true },
   });
   for (const m of dueMaintenance) {
-    const r = await processWorkflowTrigger('maintenance_due', {
+    const r = await processWorkflowTrigger("maintenance_due", {
       maintenanceId: m.id,
       maintenanceTitle: m.title,
       assetId: m.assetId,
       assetName: m.asset.assetname,
       nextDueDate: m.nextDueDate.toISOString(),
     });
-    results.push({ trigger: 'maintenance_due', ...r });
+    results.push({ trigger: "maintenance_due", ...r });
   }
 
   // 3. Check expiring licenses (within next 30 days)
@@ -268,13 +317,13 @@ export async function runScheduledWorkflows(): Promise<
     include: { licenceCategoryType: true },
   });
   for (const lic of expiringLicenses) {
-    const r = await processWorkflowTrigger('license_expiring', {
+    const r = await processWorkflowTrigger("license_expiring", {
       licenseId: lic.licenceid,
       licenseName: lic.licenceCategoryType.licencecategorytypename,
       licenseKey: lic.licencekey,
       expirationDate: lic.expirationdate?.toISOString(),
     });
-    results.push({ trigger: 'license_expiring', ...r });
+    results.push({ trigger: "license_expiring", ...r });
   }
 
   // 4. Check low stock consumables
@@ -283,13 +332,13 @@ export async function runScheduledWorkflows(): Promise<
   });
   const lowStock = allConsumables.filter((c) => c.quantity <= c.minQuantity);
   for (const item of lowStock) {
-    const r = await processWorkflowTrigger('stock_low', {
+    const r = await processWorkflowTrigger("stock_low", {
       consumableId: item.consumableid,
       consumableName: item.consumablename,
       quantity: item.quantity,
       minQuantity: item.minQuantity,
     });
-    results.push({ trigger: 'stock_low', ...r });
+    results.push({ trigger: "stock_low", ...r });
   }
 
   return results;


### PR DESCRIPTION
## Summary

Comprehensive security audit remediation addressing **1 CRITICAL**, **4 HIGH**, and **4 MEDIUM** severity findings, plus resilience improvements.

### CRITICAL
- **SSRF protection** for webhook and Slack/Teams URLs — DNS-based private IP blocklist blocks RFC 1918, link-local, cloud metadata endpoints (`src/lib/url-validation.ts`)

### HIGH
- **Organization IDOR** — enforce org membership check on `GET /api/organizations/[id]`
- **Sentry PII** — disable `sendDefaultPii` in all 3 configs (server, edge, client)
- **Account lockout** — migrate from in-memory `Map` to PostgreSQL-backed UNLOGGED table with atomic upserts (survives cold starts, works across serverless instances)

### MEDIUM
- **Magic-bytes upload validation** — verify file content matches extension (PNG, JPG, GIF, WebP, PDF, DOCX, XLSX)
- **Demo-reset guard** — require `DEMO_ALLOW_RESET=true` env var in addition to `DEMO_MODE`
- **Error response sanitization** — strip Zod field paths from validation errors, expose only messages
- **Structured logging** — replace 17 `console.error/warn` calls with `logger` across 7 lib files

### Resilience improvements
- Replace 37 silent `.catch(() => {})` on audit logs, integrations, and BetterAuth sync with `logCatchError()` handlers
- Add 30s timeout to Intune Graph API calls via `AbortController`
- Add 10s timeout to Slack/Teams webhook notifications

## Test plan

- [ ] Type check passes (`npx tsc --noEmit` — no new errors)
- [ ] Webhook creation with `http://127.0.0.1` or `http://169.254.169.254` blocked by SSRF validation
- [ ] Non-admin user cannot GET another org's data at `/api/organizations/[id]`
- [ ] Account lockout persists across page reloads (DB-backed, not in-memory)
- [ ] File upload with renamed `.exe` → `.png` rejected by magic-bytes check
- [ ] Demo-reset cron returns 403 without `DEMO_ALLOW_RESET=true`
- [ ] Sentry dashboard no longer receives user emails/IPs
- [ ] Logger output shows warnings for previously silent catch failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches security-critical paths (auth lockout, outbound webhook delivery, and org authorization) and changes runtime behavior around login, network calls, and error handling; regressions could block logins or integrations if misconfigured.
> 
> **Overview**
> **Security hardening across auth, outbound requests, and telemetry.** Disables Sentry `sendDefaultPii` (edge/server/client), adds SSRF protection for outbound `webhooks` and Slack/Teams notifications via new `validateOutboundUrl`, and prevents organization IDOR by restricting `GET /api/organizations/[id]` to the caller’s org unless admin.
> 
> **Lockout and operational resilience improvements.** Replaces the in-memory account lockout `Map` with a PostgreSQL-backed `account_lockouts` table (atomic upsert/reset, fail-open), updates auth middleware to await the new async lockout APIs, and adds upload magic-bytes validation for asset attachments.
> 
> **Safer failures and observability.** Adds `logCatchError()` and replaces many silent fire-and-forget `.catch(() => {})` with logged warnings, swaps `console.*` with `logger` in several libs, tightens demo reset with `DEMO_ALLOW_RESET=true`, adds timeouts to Intune Graph and Slack/Teams webhooks, and sanitizes Zod validation error responses to return only messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0fe440ad2edf512891177e2cda44fa296dcb8f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->